### PR TITLE
Refactor: Replace unsemantic div tags with semantic HTML5 tags

### DIFF
--- a/src/app/(main)/novels/[slug]/page.tsx
+++ b/src/app/(main)/novels/[slug]/page.tsx
@@ -108,9 +108,9 @@ export default async function NovelPage({ params }: { params: Promise<{ slug: st
 
   const chapters = novel.chapters;
   return (
-    <div className='p-2 sm:p-4'>
+    <article className='p-2 sm:p-4'>
       {/* Hero Section with Cover and Info */}
-      <div className='mb-8'>
+      <header className='mb-8'>
         <div className='flex flex-col lg:flex-row items-center gap-8'>
           {/* Cover Image */}
           <div className='flex-shrink-0'>
@@ -176,10 +176,10 @@ export default async function NovelPage({ params }: { params: Promise<{ slug: st
             </Card>
           </div>
         </div>
-      </div>
+      </header>
 
       {/* Novel Description */}
-      <div className="mb-8">
+      <section className="mb-8">
         <Card className="glass">
           <CardContent className="p-6">
             <div
@@ -188,18 +188,18 @@ export default async function NovelPage({ params }: { params: Promise<{ slug: st
             />
           </CardContent>
         </Card>
-      </div>
+      </section>
 
       {/* Chapters Section */}
-      <div className='mt-8'>
-        <div className="flex items-center justify-between mb-6">
+      <section className='mt-8'>
+        <header className="flex items-center justify-between mb-6">
           <H2 className="text-2xl font-bold text-gradient-indigo-violet">Chapters</H2>
-          <div className="text-sm text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             {chapters.length} total chapters
-          </div>
-        </div>
+          </p>
+        </header>
         <ChapterList novelId={novel.id} novelSlug={paramsResolved.slug} data={chapters} />
-      </div>
-    </div>
+      </section>
+    </article>
   )
 }

--- a/src/app/(main)/novels/page.tsx
+++ b/src/app/(main)/novels/page.tsx
@@ -65,13 +65,13 @@ const getCacheData = unstable_cache(getNovelList, ["novels"], {
 export default async function NovelList() {
   const novels = await getCacheData()
   return (
-    <div className='p-4'>
-      <div className="text-center mb-12">
+    <section className='p-4'>
+      <header className="text-center mb-12">
         <H2 className="text-3xl font-bold text-gradient-indigo-violet mb-4">Discover Amazing Novels</H2>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
           Explore our collection of fan-translated Asian web novels. Each story is carefully translated and edited by passionate fans.
         </p>
-      </div>
+      </header>
       
       <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
         {novels.map(novel => novel.chapters.length > 0 ? (
@@ -145,6 +145,6 @@ export default async function NovelList() {
           </p>
         </DecorativeEmptyState>
       )}
-    </div>
+    </section>
   )
 }

--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -36,7 +36,7 @@ export default function Navbar() {
   }, [])
 
   return (
-    <div className={cn(
+    <nav className={cn(
       'flex justify-between items-center sticky top-0 z-50 bg-background border-b-brutal-lg border-black dark:border-white transition-shadow duration-300',
       scrolled && 'shadow-brutal-lg dark:shadow-white'
     )}>
@@ -108,6 +108,6 @@ export default function Navbar() {
           </SignInButton>
         </SignedOut>
       </div>
-    </div>
+    </nav>
   )
 }

--- a/src/components/shared/chapter-page.tsx
+++ b/src/components/shared/chapter-page.tsx
@@ -22,9 +22,9 @@ commentSection
   const previous = chapter.previous
   const next = chapter.next
   return (
-    <div className='p-4 space-y-6'>
+    <main className='p-4 space-y-6'>
       {/* Reading container with neobrutalism styling */}
-      <div className='max-w-4xl mx-auto bg-background md:border-brutal md:border-black md:dark:border-white rounded-lg md:shadow-brutal-lg p-2 md:p-12'>
+      <section className='max-w-4xl mx-auto bg-background md:border-brutal md:border-black md:dark:border-white rounded-lg md:shadow-brutal-lg p-2 md:p-12'>
         <H3 className='border-b-4 border-brutal-cyan pb-2 mb-6'>Chapter {chapter.number}: {chapter.title}</H3>
         {(chapter.premium) ? 
         <>
@@ -40,10 +40,10 @@ commentSection
         :(
           <article className='space-y-2 prose lg:prose-xl dark:prose-invert max-w-none chapter-content' dangerouslySetInnerHTML={{__html: chapter.content}} />
         )}
-      </div>
+      </section>
 
       {/* Chapter navigation with neobrutalism styling */}
-      <div className='max-w-4xl mx-auto flex flex-wrap gap-3 justify-center items-center'>
+      <nav className='max-w-4xl mx-auto flex flex-wrap gap-3 justify-center items-center'>
         {previous ? (
           <Link href={`/novels/${novelSlug}/${previous.slug}`}>
             <Button className='bg-brutal-yellow hover:bg-brutal-yellow text-black border-brutal border-black dark:border-white shadow-brutal hover:shadow-brutal-lg hover:-translate-x-0.5 hover:-translate-y-0.5 transition-all'>
@@ -72,12 +72,12 @@ commentSection
           </Button>
         )}
         <ChapterNavigation previousLink={previous ? `/novels/${novelSlug}/${previous.slug}` : undefined} nextLink={next ? `/novels/${novelSlug}/${next.slug}` : undefined} />
-      </div>
+      </nav>
 
       <NovelSuggestions currentNovelId={chapter.novelId} count={3} />
       <JoinDiscord />
       {commentSection}
       {/* <ScrollToTop /> */}
-    </div>
+    </main>
   )
 }


### PR DESCRIPTION
Replaced `div` tags with logical semantic tags (`<nav>`, `<main>`, `<section>`, `<article>`, `<header>`, etc.) in key layout files where appropriate, without blindly replacing strictly functional flex/grid wrappers. This improves WCAG compliance and professional code structure.

---
*PR created automatically by Jules for task [2974512536473108692](https://jules.google.com/task/2974512536473108692) started by @Shashank3736*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated markup structure to use semantic HTML elements across novel pages, navigation components, and chapter reading interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->